### PR TITLE
Fix ABA-55 CFT se debe mostrar con dos decimales

### DIFF
--- a/app/scripts/controllers/loanAccount/NewLoanAccAppController.js
+++ b/app/scripts/controllers/loanAccount/NewLoanAccAppController.js
@@ -302,7 +302,7 @@
                 if(scope.formData.loanTermFrequencyType == 2){
                     period = period/12;
                 }
-                let effectInterestAmount = (1 + interest / period) * period - 1;
+                let effectInterestAmount = ((1 + interest / period) * period - 1).toFixed(2);
 
                 console.log(period, interest, effectInterestAmount);
                 scope.tasaeffectiva = effectInterestAmount;


### PR DESCRIPTION
## Description
When a new loan is being created, the effective interest rate is shown with 2 decimal places.

## Related issues and discussion
ABA-55

